### PR TITLE
add [-15,15] bound for coordinates' speed

### DIFF
--- a/mocoPFJCF.py
+++ b/mocoPFJCF.py
@@ -217,9 +217,10 @@ problem = study.updProblem()
 ########## Bounds
 # set joint RoM as min and max bounds for each free coordinate
 for i in model.getCoordinateSet():
+	name = i.getAbsolutePathString()
 	if i.getMotionType()!=3 and i.get_locked()==False:
-		name = i.getAbsolutePathString()+'/value'
-		problem.setStateInfo(name, [i.getRangeMin(), i.getRangeMax()])
+		problem.setStateInfo(name+'/value', [i.getRangeMin(), i.getRangeMax()])
+		problem.setStateInfo(name+'/speed', [-15, 15])
 
 # problem.setStateInfoPattern('/forceset/.*/activation', [0, 1])
 # problem.setStateInfoPattern('/forceset/.*/normalized_tendon_force', [0, 1.8], [], []);


### PR DESCRIPTION
@aaronsfox We can set bounds for coordinates' speed. This graph (Analyze>Kinematics) shows that a bound of [-15,15] (rad/s or m/s) might be an appropriate range for all coordinates' speed:
![u](https://user-images.githubusercontent.com/38867713/231951709-142204cd-cc39-4cfa-a5ae-647e5d5fdc07.png)
Please let me know your thoughts. Is 15 appropriate? I saw somewhere 50 but I can't find it.